### PR TITLE
[FIX]Make payload encode value null for get request

### DIFF
--- a/sageone_signer.php
+++ b/sageone_signer.php
@@ -114,7 +114,11 @@ class SageoneSigner {
 	/* base64 encode the request body */
 	private function encodedBody() {
 		$body = array();
-		$encoded = base64_encode($this->request_body_params);
+		$encode=null;
+		if(!is_array($this->request_body_params)){
+			
+			$encoded = base64_encode($this->request_body_params);
+		}
 		$body["body"] = $encoded;
 		return $body;
 	}

--- a/sageone_signer.php
+++ b/sageone_signer.php
@@ -114,7 +114,7 @@ class SageoneSigner {
 	/* base64 encode the request body */
 	private function encodedBody() {
 		$body = array();
-		$encode=null;
+		$encoded=null;
 		if(!is_array($this->request_body_params)){
 			
 			$encoded = base64_encode($this->request_body_params);


### PR DESCRIPTION
Currently following line produces warning. This would remove that warning
``` 
      $encoded = base64_encode($this->request_body_params);
```