### PR TITLE
Quotes to prevent error when PWD contains space

### DIFF
--- a/script/start.sh
+++ b/script/start.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo Starting container ...
-docker run -d --name sageone_api_php_sample -p 8080:80 --volume=`pwd`:/var/www/html sageone_api_php_sample
+docker run -d --name sageone_api_php_sample -p 8080:80 --volume="`pwd`:/var/www/html" sageone_api_php_sample


### PR DESCRIPTION
Added quotes to the path so that when `pwd` was expanded, if it contained a space it wouldn't generate the following generic error:

> docker: invalid reference format: repository name must be lowercase.